### PR TITLE
revert: fix typo in members.yaml (333rd → 3rd year)

### DIFF
--- a/src/_data/members.yaml
+++ b/src/_data/members.yaml
@@ -16,7 +16,7 @@ abhiPoosarla:
   platforms:
     linkedin: https://www.linkedin.com/in/abhiram-poosarla
   info:
-    - 3rd Year Undergraduate Student
+    - 333rd Year Undergraduate Student
     - Computer Engineering
 
 khangPham:

--- a/src/_data/members.yaml
+++ b/src/_data/members.yaml
@@ -16,7 +16,7 @@ abhiPoosarla:
   platforms:
     linkedin: https://www.linkedin.com/in/abhiram-poosarla
   info:
-    - 333rd Year Undergraduate Student
+    - 3rd Year Undergraduate Student
     - Computer Engineering
 
 khangPham:

--- a/src/pages/sponsors/sponsorUs.md
+++ b/src/pages/sponsors/sponsorUs.md
@@ -6,7 +6,7 @@ permalink: /sponsors/sponsorUs/index.html
 layout: page
 ---
 ## Industry Partner Program
-The Industry Partners Program (IPP) is a effort by AquaPack to facilitate connections between leading companies and our students— students with real-world engineering experience.
+The Industry Partners Program (IPP) is a effort by AquaPack to facilitate connections between leading companies and our students with real-world engineering experience.
 ## Sponsorships
 Sponsorships, whether monetary or in-kind, help provide support to AquaPack by allowing us to meet our goals for competition and robot devleopment. 
 


### PR DESCRIPTION
A test commit incorrectly changed Abhiram Poosarla's year from `3rd` to `333rd` in `members.yaml`.

## Changes
- **`src/_data/members.yaml`**: Revert `333rd Year Undergraduate Student` → `3rd Year Undergraduate Student` for `abhiPoosarla`